### PR TITLE
Fix busy loop in ComputerVisionDemo

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -159,9 +159,14 @@ namespace ComputerVisionDemo
             do
             {
                 results = await client.GetReadResultAsync(Guid.Parse(operationId));
+                if (results.Status == OperationStatusCodes.Running ||
+                    results.Status == OperationStatusCodes.NotStarted)
+                {
+                    await Task.Delay(1000);
+                }
             }
-            while ((results.Status == OperationStatusCodes.Running ||
-                results.Status == OperationStatusCodes.NotStarted));
+            while (results.Status == OperationStatusCodes.Running ||
+                results.Status == OperationStatusCodes.NotStarted);
 
             Console.WriteLine();
             var textUrlFileResults = results.AnalyzeResult.ReadResults;


### PR DESCRIPTION
## Summary
- add delay while polling text extraction results

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6845668eaac48323960bf8c7166f6b6c